### PR TITLE
Fix(avd_to_clab): Rename uplink_interfaces to AVD key

### DIFF
--- a/ansible_collections/titom73/avd_tools/roles/avd_to_clab/templates/topology.yml.j2
+++ b/ansible_collections/titom73/avd_tools/roles/avd_to_clab/templates/topology.yml.j2
@@ -84,11 +84,13 @@ topology:
 {%     for node_group in node_types[node_type]['node_groups'] | arista.avd.natural_sort %}
 {%         for node in node_types[node_type]['node_groups'][node_group]['nodes'] | arista.avd.natural_sort %}
 {# UPLINK interfaces #}
-{%             for uplink_switch_interface in node_types[node_type]['node_groups'][node_group]['nodes'][node].uplink_switch_interfaces %}
-{%                 set uplink_interfaces = node_types[node_type]['node_groups'][node_group]['nodes'][node].uplink_interfaces | arista.avd.default( node_types[node_type]['node_groups'][node_group].uplink_interfaces, node_types[node_type].defaults.uplink_interfaces ) %}
+{%             for uplink_switch_interface in node_types[node_type]['node_groups'][node_group]['nodes'][node].uplink_switch_interfaces | arista.avd.natural_sort %}
+{%                 set uplink_interfaces = node_types[node_type]['node_groups'][node_group]['nodes'][node].uplink_switch_interfaces | arista.avd.default( node_types[node_type]['node_groups'][node_group].uplink_switch_interfaces, node_types[node_type].defaults.uplink_switch_interfaces ) %}
 {%                 set uplink_switches = node_types[node_type]['node_groups'][node_group]['nodes'].uplink_switches | arista.avd.default( node_types[node_type]['node_groups'][node_group].uplink_switches, node_types[node_type].defaults.uplink_switches ) %}
+{%                 if uplink_interfaces is arista.avd.defined() %}
     - endpoints: ["{{ node }}:{{ uplink_interfaces[loop.index0]| replace('Ethernet', 'eth')  }}", "{{ uplink_switches[ loop.index0 ] }}:{{ uplink_switch_interface | replace('Ethernet', 'eth') }}"]
-{%                 endfor %}
+{%                 endif %}
+{%             endfor %}
 {# - End Uplink Interfaces #}
 {# - MLAG interfaces #}
 {%             if loop.index == 1 and node_types[node_type]['node_groups'][node_group]['nodes'] | length > 1 %}
@@ -105,7 +107,7 @@ topology:
 {# --------------------- FLAT NODES LIST --------------------- #}
 {%     for node in node_types[node_type]['nodes'] | arista.avd.natural_sort %}
 {%         for uplink_switch_interface in node_types[node_type]['nodes'][node].uplink_switch_interfaces | arista.avd.natural_sort %}
-{%             set uplink_interfaces = node_types[node_type]['nodes'][node].uplink_interfaces | arista.avd.default( node_types[node_type].uplink_interfaces, node_types[node_type].defaults.uplink_interfaces ) %}
+{%             set uplink_interfaces = node_types[node_type]['nodes'][node].uplink_interfaces | arista.avd.default( node_types[node_type].uplink_switch_interfaces, node_types[node_type].defaults.uplink_switch_interfaces ) %}
 {%             set uplink_switches = node_types[node_type]['nodes'][node].uplink_switches | arista.avd.default( node_types[node_type]['nodes'].uplink_switches, node_types[node_type].defaults.uplink_switches ) %}
     - endpoints: ["{{ node }}:{{ uplink_interfaces[loop.index0] | replace('Ethernet', 'eth')}}", "{{ uplink_switches[ loop.index0 ] }}:{{ uplink_switch_interface | replace('Ethernet', 'eth') }}"]
 {%         endfor %}


### PR DESCRIPTION
- Use correct avd key for uplink interfaces with `uplink_switch_interfaces`
- Add protection for links in node groups to support mlag on top of the
  fabric like spines